### PR TITLE
Add constraint computeAllowedInstanceLabels

### DIFF
--- a/tools/custom-organization-policy-library/build/config/services/schema.compute.yaml
+++ b/tools/custom-organization-policy-library/build/config/services/schema.compute.yaml
@@ -18,3 +18,7 @@ compute:
     bundles:
       pci-dss: false
       cis: true
+    params:
+      #@schema/validation min_len=1
+      labels:
+      - ""

--- a/tools/custom-organization-policy-library/build/custom-constraints/compute/computeAllowedInstanceLabels.yaml
+++ b/tools/custom-organization-policy-library/build/custom-constraints/compute/computeAllowedInstanceLabels.yaml
@@ -1,12 +1,16 @@
 #@ load("/constraints.lib.star", "build_constraint")
 #@ constraint = build_constraint("computeAllowedInstanceLabels")
 
+#@ def condition(labels):
+#@   return "resource.labels.all(label, (label in " + str(labels) + ")) == false"
+#@ end
+
 #@ if constraint.to_generate():
 name: #@ constraint.constraint_name()
-resource_types: compute.googleapis.com/Firewall
-condition: 1 == 1
+resource_types: compute.googleapis.com/Instance
+condition: #@  condition(constraint.params().labels)
 action_type: DENY
 method_types: CREATE
-display_name: Enforce Compute Instance Rule naming Convention
-description:  "Enforce that every Firewall Rule created are named according to regular expression pattern"
+display_name: Allow only specific labels
+description:  "Prevent the creation of VMs not having the expected labels"
 #@ end

--- a/tools/custom-organization-policy-library/samples/constraints/compute/computeAllowedInstanceLabels.yaml
+++ b/tools/custom-organization-policy-library/samples/constraints/compute/computeAllowedInstanceLabels.yaml
@@ -1,7 +1,7 @@
 name: organizations/11111111/customConstraints/custom.computeAllowedInstanceLabels
-resource_types: compute.googleapis.com/Firewall
-condition: 1 == 1
+resource_types: compute.googleapis.com/Instance
+condition: resource.labels.all(label, (label in ["label1", "label2"])) == false
 action_type: DENY
 method_types: CREATE
-display_name: Enforce Compute Instance Rule naming Convention
-description: Enforce that every Firewall Rule created are named according to regular expression pattern
+display_name: Allow only specific labels
+description: Prevent the creation of VMs not having the expected labels

--- a/tools/custom-organization-policy-library/values.yaml
+++ b/tools/custom-organization-policy-library/values.yaml
@@ -4,3 +4,9 @@ organization: '11111111'
 bundles:
   pci-dss: false
   cis: false
+compute:
+  computeAllowedInstanceLabels:
+    params:
+      labels:
+      - "label1"
+      - "label2"


### PR DESCRIPTION
Example of CuOP with parameters. Here are the steps to do:

1. In tools/custom-organization-policy-library/build/config/services/schema.XXXX.yaml, 
add a params with the name of the param with empty list. For this constraint the parameter name choosen was `labels` which is an array
```
    params:
      #@schema/validation min_len=1
      labels:
      - ""
```
2. In tools/custom-organization-policy-library/build/custom-constraints/compute/computeAllowedInstanceLabels.yaml
Update the constraint in build folder to generate the good condition based on the input of parameter
This part depends a lot of the case. In this example, i check that if any label is set to the VM, only label from a whitelist are used.

3. Update the file tools/custom-organization-policy-library/values.yaml with some value as default that can be used as parameter. This is needed to be able to generate with a list of value.

4. Finally push the generaed file
