### PR TITLE
Fix multi-line description formatting in Terraform constraint conversion

### DIFF
--- a/tools/custom-organization-policy-library/samples/tf/custom-constraints/custom.firewallRestrictCacheSearchDatabasesPolicyRule.yaml
+++ b/tools/custom-organization-policy-library/samples/tf/custom-constraints/custom.firewallRestrictCacheSearchDatabasesPolicyRule.yaml
@@ -13,10 +13,8 @@ custom.firewallRestrictCacheSearchDatabasesPolicyRule:
         )
       )
     )
-  description: 'Ensure that cache and search database ports (Elasticsearch, Memcached,
-    Redis) are not accessible
-
-    from the Internet when using Firewall Policy Rule'
+  description: Ensure that cache and search database ports (Elasticsearch, Memcached,
+    Redis) are not accessible from the Internet when using Firewall Policy Rule
   display_name: Restrict Firewall Policy rules allowing cache/search database port
     access from the Internet
   method_types:

--- a/tools/custom-organization-policy-library/samples/tf/custom-constraints/custom.firewallRestrictCacheSearchDatabasesRule.yaml
+++ b/tools/custom-organization-policy-library/samples/tf/custom-constraints/custom.firewallRestrictCacheSearchDatabasesRule.yaml
@@ -11,10 +11,8 @@ custom.firewallRestrictCacheSearchDatabasesRule:
             rule.IPProtocol == 'udp' && port in ['11211', '11214', '11215']
         )
       )
-  description: 'Ensure that cache and search database ports (Elasticsearch, Memcached,
-    Redis) are not accessible
-
-    from the Internet when using VPC Firewall Rule.'
+  description: Ensure that cache and search database ports (Elasticsearch, Memcached,
+    Redis) are not accessible from the Internet when using VPC Firewall Rule.
   display_name: Restrict VPC Firewall rules allowing cache/search database port access
     from the Internet
   method_types:

--- a/tools/custom-organization-policy-library/samples/tf/custom-constraints/custom.firewallRestrictDirectoryServicesPolicyRule.yaml
+++ b/tools/custom-organization-policy-library/samples/tf/custom-constraints/custom.firewallRestrictDirectoryServicesPolicyRule.yaml
@@ -14,10 +14,8 @@ custom.firewallRestrictDirectoryServicesPolicyRule:
         l4config.ports.exists(port, port == '445' || port == '389')
       )
     )
-  description: 'Ensure that directory and authentication services (SMB/CIFS, LDAP)
-    are not accessible from the
-
-    Internet when using Firewall Policy Rule'
+  description: Ensure that directory and authentication services (SMB/CIFS, LDAP)
+    are not accessible from the Internet when using Firewall Policy Rule
   display_name: Restrict Firewall Policy rules allowing directory service access from
     the Internet
   method_types:

--- a/tools/custom-organization-policy-library/samples/tf/custom-constraints/custom.firewallRestrictDirectoryServicesRule.yaml
+++ b/tools/custom-organization-policy-library/samples/tf/custom-constraints/custom.firewallRestrictDirectoryServicesRule.yaml
@@ -11,10 +11,8 @@ custom.firewallRestrictDirectoryServicesRule:
             rule.IPProtocol == 'udp' && port in ['445', '389']
         )
       )
-  description: 'Ensure that directory and authentication services (SMB/CIFS, LDAP)
-    are not accessible from the
-
-    Internet when using VPC Firewall Rule'
+  description: Ensure that directory and authentication services (SMB/CIFS, LDAP)
+    are not accessible from the Internet when using VPC Firewall Rule
   display_name: Restrict VPC Firewall rules allowing directory service access from
     the Internet
   method_types:

--- a/tools/custom-organization-policy-library/samples/tf/custom-constraints/custom.firewallRestrictExplicitAllPortsPolicyRule.yaml
+++ b/tools/custom-organization-policy-library/samples/tf/custom-constraints/custom.firewallRestrictExplicitAllPortsPolicyRule.yaml
@@ -11,10 +11,8 @@ custom.firewallRestrictExplicitAllPortsPolicyRule:
         )
       )
     )
-  description: 'Prevent Firewall Policy rules that explicitly specify all TCP/UDP
-    ports using ranges like 0-65535 or 1-65535
-
-    '
+  description: Prevent Firewall Policy rules that explicitly specify all TCP/UDP ports
+    using ranges like 0-65535 or 1-65535
   display_name: Restrict Firewall Policy rules with explicit all-ports specifications
   method_types:
   - CREATE

--- a/tools/custom-organization-policy-library/samples/tf/custom-constraints/custom.firewallRestrictInsecureProtocolsPolicyRule.yaml
+++ b/tools/custom-organization-policy-library/samples/tf/custom-constraints/custom.firewallRestrictInsecureProtocolsPolicyRule.yaml
@@ -13,10 +13,8 @@ custom.firewallRestrictInsecureProtocolsPolicyRule:
         )
       )
     )
-  description: 'Ensure that insecure legacy protocols (Telnet, FTP, HTTP) are not
-    accessible from the Internet when
-
-    using Firewall Policy Rule'
+  description: Ensure that insecure legacy protocols (Telnet, FTP, HTTP) are not accessible
+    from the Internet when using Firewall Policy Rule
   display_name: Restrict Firewall Policy rules allowing insecure protocol access from
     the Internet
   method_types:

--- a/tools/custom-organization-policy-library/samples/tf/custom-constraints/custom.firewallRestrictInsecureProtocolsRule.yaml
+++ b/tools/custom-organization-policy-library/samples/tf/custom-constraints/custom.firewallRestrictInsecureProtocolsRule.yaml
@@ -10,10 +10,8 @@ custom.firewallRestrictInsecureProtocolsRule:
             rule.IPProtocol == 'tcp' && port in ['21', '23', '80']
         )
       )
-  description: 'Ensure that insecure legacy protocols (Telnet, FTP, HTTP) are not
-    accessible from the Internet when
-
-    using VPC Firewall Rule'
+  description: Ensure that insecure legacy protocols (Telnet, FTP, HTTP) are not accessible
+    from the Internet when using VPC Firewall Rule
   display_name: Restrict VPC Firewall rules allowing insecure protocol access from
     the Internet
   method_types:

--- a/tools/custom-organization-policy-library/samples/tf/custom-constraints/custom.firewallRestrictMailProtocolsPolicyRule.yaml
+++ b/tools/custom-organization-policy-library/samples/tf/custom-constraints/custom.firewallRestrictMailProtocolsPolicyRule.yaml
@@ -12,10 +12,8 @@ custom.firewallRestrictMailProtocolsPolicyRule:
         l4config.ports.exists(port, port == '25' || port == '110')
       )
     )
-  description: 'Ensure that mail protocols (SMTP, POP3) are not accessible from the
+  description: Ensure that mail protocols (SMTP, POP3) are not accessible from the
     Internet when using Firewall Policy Rule
-
-    '
   display_name: Restrict Firewall Policy rules allowing mail protocol access from
     the Internet
   method_types:

--- a/tools/custom-organization-policy-library/samples/tf/custom-constraints/custom.firewallRestrictManagementPortsPolicyRule.yaml
+++ b/tools/custom-organization-policy-library/samples/tf/custom-constraints/custom.firewallRestrictManagementPortsPolicyRule.yaml
@@ -14,10 +14,8 @@ custom.firewallRestrictManagementPortsPolicyRule:
         )
       )
     )
-  description: 'Ensure that management interfaces (Cisco Secure WebSM) are not accessible
-    from the Internet when
-
-    using Firewall Policy Rule'
+  description: Ensure that management interfaces (Cisco Secure WebSM) are not accessible
+    from the Internet when using Firewall Policy Rule
   display_name: Restrict Firewall Policy rules allowing management port access from
     the Internet
   method_types:

--- a/tools/custom-organization-policy-library/samples/tf/custom-constraints/custom.firewallRestrictManagementPortsRule.yaml
+++ b/tools/custom-organization-policy-library/samples/tf/custom-constraints/custom.firewallRestrictManagementPortsRule.yaml
@@ -11,10 +11,8 @@ custom.firewallRestrictManagementPortsRule:
             port in ['9090']
         )
       )
-  description: 'Ensure that management interfaces (Cisco Secure WebSM) are not accessible
-    from the Internet when
-
-    using VPC Firewall Rule'
+  description: Ensure that management interfaces (Cisco Secure WebSM) are not accessible
+    from the Internet when using VPC Firewall Rule
   display_name: Restrict VPC Firewall rules allowing management port access from the
     Internet
   method_types:

--- a/tools/custom-organization-policy-library/samples/tf/custom-constraints/custom.firewallRestrictNetworkServicesPolicyRule.yaml
+++ b/tools/custom-organization-policy-library/samples/tf/custom-constraints/custom.firewallRestrictNetworkServicesPolicyRule.yaml
@@ -14,10 +14,8 @@ custom.firewallRestrictNetworkServicesPolicyRule:
         l4config.ports.exists(port, port == '53' || port == '137' || port == '138' || port == '139')
       )
     )
-  description: 'Ensure that network infrastructure services (DNS, NetBIOS) are not
-    accessible from the Internet when
-
-    using Firewall Policy Rule'
+  description: Ensure that network infrastructure services (DNS, NetBIOS) are not
+    accessible from the Internet when using Firewall Policy Rule
   display_name: Restrict Firewall Policy rules allowing network service access from
     the Internet
   method_types:

--- a/tools/custom-organization-policy-library/samples/tf/custom-constraints/custom.firewallRestrictNetworkServicesRule.yaml
+++ b/tools/custom-organization-policy-library/samples/tf/custom-constraints/custom.firewallRestrictNetworkServicesRule.yaml
@@ -11,10 +11,8 @@ custom.firewallRestrictNetworkServicesRule:
             rule.IPProtocol == 'udp' && port in ['53', '137', '138', '139']
         )
       )
-  description: 'Ensure that network infrastructure services (DNS, NetBIOS) are not
-    accessible from the Internet when
-
-    using VPC Firewall Rule'
+  description: Ensure that network infrastructure services (DNS, NetBIOS) are not
+    accessible from the Internet when using VPC Firewall Rule
   display_name: Restrict VPC Firewall rules allowing network service access from the
     Internet
   method_types:

--- a/tools/custom-organization-policy-library/samples/tf/custom-constraints/custom.firewallRestrictNoSQLDatabasesPolicyRule.yaml
+++ b/tools/custom-organization-policy-library/samples/tf/custom-constraints/custom.firewallRestrictNoSQLDatabasesPolicyRule.yaml
@@ -15,10 +15,8 @@ custom.firewallRestrictNoSQLDatabasesPolicyRule:
         )
       )
     )
-  description: 'Ensure that NoSQL database ports (Cassandra, MongoDB) are not accessible
-    from the Internet when
-
-    using Firewall Policy Rule'
+  description: Ensure that NoSQL database ports (Cassandra, MongoDB) are not accessible
+    from the Internet when using Firewall Policy Rule
   display_name: Restrict Firewall Policy rules allowing NoSQL database port access
     from the Internet
   method_types:

--- a/tools/custom-organization-policy-library/samples/tf/custom-constraints/custom.firewallRestrictNoSQLDatabasesRule.yaml
+++ b/tools/custom-organization-policy-library/samples/tf/custom-constraints/custom.firewallRestrictNoSQLDatabasesRule.yaml
@@ -11,10 +11,8 @@ custom.firewallRestrictNoSQLDatabasesRule:
             port in ["7000", "7001", "7199", "8888", "9042", "9160", "61620", "61621", "27017", "27018", "27019"]
         )
       )
-  description: 'Ensure that NoSQL database ports (Cassandra, MongoDB) are not accessible
-    from the Internet when
-
-    using Firewall Policy Rule'
+  description: Ensure that NoSQL database ports (Cassandra, MongoDB) are not accessible
+    from the Internet when using Firewall Policy Rule
   display_name: Restrict VPC Firewall rules allowing NoSQL database port access from
     the Internet
   method_types:

--- a/tools/custom-organization-policy-library/samples/tf/custom-constraints/custom.firewallRestrictOpenFirewallPolicyRule.yaml
+++ b/tools/custom-organization-policy-library/samples/tf/custom-constraints/custom.firewallRestrictOpenFirewallPolicyRule.yaml
@@ -9,12 +9,9 @@ custom.firewallRestrictOpenFirewallPolicyRule:
         (!has(l4.ports) || size(l4.ports) == 0)
       )
     )
-  description: 'Prevent Firewall Policy rules that are open to 0.0.0.0/0
-
-    (except ICMP, TCP:22/TCP:443/TCP:3389/UDP:3389/SCTP:22) or that allow all TCP/UDP
-    ports
-
-    from non-private IPs'
+  description: Prevent Firewall Policy rules that are open to 0.0.0.0/0 (except ICMP,
+    TCP:22/TCP:443/TCP:3389/UDP:3389/SCTP:22) or that allow all TCP/UDP ports from
+    non-private IPs
   display_name: Restrict overly permissive Firewall Policy rules open to the Internet
   method_types:
   - CREATE

--- a/tools/custom-organization-policy-library/samples/tf/custom-constraints/custom.firewallRestrictOpenFirewallRule.yaml
+++ b/tools/custom-organization-policy-library/samples/tf/custom-constraints/custom.firewallRestrictOpenFirewallRule.yaml
@@ -14,10 +14,9 @@ custom.firewallRestrictOpenFirewallRule:
       !resource.name.startsWith('gkegw1-l7-') &&
       !resource.name.startsWith('gkemcg1-l7-')
     )
-  description: 'Prevent VPC firewall rules that are open to 0.0.0.0/0 (except for
-    safe protocols like ICMP, SSH,
-
-    HTTPS, RDP) or allow all TCP/UDP ports from non-private IPs'
+  description: Prevent VPC firewall rules that are open to 0.0.0.0/0 (except for safe
+    protocols like ICMP, SSH, HTTPS, RDP) or allow all TCP/UDP ports from non-private
+    IPs
   display_name: Restrict overly permissive VPC Firewall rules open to the Internet
   method_types:
   - CREATE

--- a/tools/custom-organization-policy-library/samples/tf/custom-constraints/custom.firewallRestrictPublicAccessPolicyRule.yaml
+++ b/tools/custom-organization-policy-library/samples/tf/custom-constraints/custom.firewallRestrictPublicAccessPolicyRule.yaml
@@ -12,10 +12,9 @@ custom.firewallRestrictPublicAccessPolicyRule:
         (l4.ipProtocol == 'sctp' && has(l4.ports) && '22' in l4.ports)
       )
     )
-  description: 'Prevent Firewall Policy rules from 0.0.0.0/0 except for allowed protocols
-    (ICMP, TCP:443, UDP:3389,
-
-    SCTP:22). TCP:22 and TCP:3389 are handled by separate constraints.'
+  description: Prevent Firewall Policy rules from 0.0.0.0/0 except for allowed protocols
+    (ICMP, TCP:443, UDP:3389, SCTP:22). TCP:22 and TCP:3389 are handled by separate
+    constraints.
   display_name: Restrict Firewall Policy rules allowing public Internet access
   method_types:
   - CREATE

--- a/tools/custom-organization-policy-library/samples/tf/custom-constraints/custom.firewallRestrictRule.yaml
+++ b/tools/custom-organization-policy-library/samples/tf/custom-constraints/custom.firewallRestrictRule.yaml
@@ -10,10 +10,8 @@ custom.firewallRestrictRule:
         range in ["192.168.32.0/24", "10.16.0.0/16"]
       )
     )
-  description: 'Prevent the creation of VPC firewall rule by providing some parameters
+  description: Prevent the creation of VPC firewall rule by providing some parameters
     (such as direction, port, ip range, protocol)
-
-    '
   display_name: Restrict VPC Firewall rules with certain configuration
   method_types:
   - CREATE

--- a/tools/custom-organization-policy-library/samples/tf/custom-constraints/custom.firewallRestrictSQLDatabasesPolicyRule.yaml
+++ b/tools/custom-organization-policy-library/samples/tf/custom-constraints/custom.firewallRestrictSQLDatabasesPolicyRule.yaml
@@ -16,10 +16,8 @@ custom.firewallRestrictSQLDatabasesPolicyRule:
         l4config.ports.exists(port, port == '2483' || port == '2484' || port == '5432')
       )
     )
-  description: 'Ensure that SQL database ports (MySQL, Oracle, PostgreSQL) are not
-    accessible from the Internet when
-
-    using Firewall Policy Rule'
+  description: Ensure that SQL database ports (MySQL, Oracle, PostgreSQL) are not
+    accessible from the Internet when using Firewall Policy Rule
   display_name: Restrict Firewall Policy rules allowing SQL database port access from
     the Internet
   method_types:

--- a/tools/custom-organization-policy-library/samples/tf/custom-constraints/custom.firewallRestrictSQLDatabasesRule.yaml
+++ b/tools/custom-organization-policy-library/samples/tf/custom-constraints/custom.firewallRestrictSQLDatabasesRule.yaml
@@ -11,10 +11,8 @@ custom.firewallRestrictSQLDatabasesRule:
             rule.IPProtocol == 'udp' && port in ['2483', '2484', '5432']
         )
       )
-  description: 'Ensure that SQL database ports (MySQL, Oracle, PostgreSQL) are not
-    accessible from the Internet when
-
-    using VPC Firewall Rule'
+  description: Ensure that SQL database ports (MySQL, Oracle, PostgreSQL) are not
+    accessible from the Internet when using VPC Firewall Rule
   display_name: Restrict VPC Firewall rules allowing SQL database port access from
     the Internet
   method_types:

--- a/tools/custom-organization-policy-library/samples/tf/custom-constraints/custom.gkeDisableClientCertificateAuthentication.yaml
+++ b/tools/custom-organization-policy-library/samples/tf/custom-constraints/custom.gkeDisableClientCertificateAuthentication.yaml
@@ -2,7 +2,7 @@ custom.gkeDisableClientCertificateAuthentication:
   action_type: DENY
   condition: |-
     resource.masterAuth.clientCertificateConfig.issueClientCertificate == true
-  description: Enforce that the API servers authentication are not using  legacy authentication
+  description: Enforce that the API servers authentication are not using legacy authentication
     method client certificate
   display_name: Disable legacy client certificate authentication
   method_types:

--- a/tools/custom-organization-policy-library/scripts/cvt-tf-constraints.py
+++ b/tools/custom-organization-policy-library/scripts/cvt-tf-constraints.py
@@ -53,6 +53,11 @@ def convert_terraform_factory(doc):
             condition_value = doc["condition"].strip()
             doc["condition"] = LiteralString(condition_value)
 
+        if "description" in doc:
+            # Replace newlines with spaces and normalize whitespace
+            description_value = " ".join(doc["description"].split())
+            doc["description"] = description_value
+
         tf_yaml = {}
         _, _, root_key = doc.get("name").rpartition("/")
         root_prefix_key = root_key  # root_key.replace("custom.", "custom.${prefix}")


### PR DESCRIPTION
## Summary
Fixes the description field formatting issue in Terraform-generated constraint files where multi-line descriptions from the source templates resulted in awkward formatting with embedded newlines.

## Changes
- Modified `scripts/cvt-tf-constraints.py` to normalize description field by replacing newlines and extra whitespace with single spaces
- Regenerated all Terraform constraints with properly formatted descriptions

## Before
```yaml
description: 'Ensure that SQL database ports (MySQL, Oracle, PostgreSQL) are not
  accessible from the Internet when

  using Firewall Policy Rule'
```

## After
```yaml
description: Ensure that SQL database ports (MySQL, Oracle, PostgreSQL) are not
  accessible from the Internet when using Firewall Policy Rule
```

## Test plan
- [x] Ran `make clean && make constraints-tf` to regenerate all constraints
- [x] Verified description formatting is correct in generated files
- [x] Checked multiple constraint files to ensure consistency