### PR TITLE
Improve firewall public access constraints with protocol exceptions and GKE exclusions

### DIFF
--- a/tools/custom-organization-policy-library/build/custom-constraints/firewall/firewallRestrictPublicAccessPolicyRule.yaml
+++ b/tools/custom-organization-policy-library/build/custom-constraints/firewall/firewallRestrictPublicAccessPolicyRule.yaml
@@ -7,11 +7,11 @@
 #@     "  rule.priority < 2147483644 &&",
 #@     "  rule.direction == 'INGRESS' &&",
 #@     "  rule.match.srcIpRanges.exists(range, range == '0.0.0.0/0') &&",
-#@     "  !rule.match.layer4Configs.exists(l4,",
+#@     "  !rule.match.layer4Configs.all(l4,",
 #@     "    l4.ipProtocol == 'icmp' ||",
-#@     "    (l4.ipProtocol == 'tcp' && has(l4.ports) && '443' in l4.ports) ||",
-#@     "    (l4.ipProtocol == 'udp' && has(l4.ports) && '3389' in l4.ports) ||",
-#@     "    (l4.ipProtocol == 'sctp' && has(l4.ports) && '22' in l4.ports)",
+#@     "    (l4.ipProtocol == 'tcp' && has(l4.ports) && l4.ports.all(p, p == '22' || p == '443' || p == '3389')) ||",
+#@     "    (l4.ipProtocol == 'udp' && has(l4.ports) && l4.ports.all(p, p == '3389')) ||",
+#@     "    (l4.ipProtocol == 'sctp' && has(l4.ports) && l4.ports.all(p, p == '22'))",
 #@     "  )",
 #@     ")"
 #@   ]
@@ -20,8 +20,8 @@
 
 #@ def description():
 #@   lines = [
-#@     "Prevent Firewall Policy rules from 0.0.0.0/0 except for allowed protocols (ICMP, TCP:443, UDP:3389,",
-#@     "SCTP:22). TCP:22 and TCP:3389 are handled by separate constraints.",
+#@     "Prevent Firewall Policy rules from 0.0.0.0/0 except for allowed protocols (ICMP,",
+#@     "TCP:22, TCP:443, TCP:3389, UDP:3389, SCTP:22)."
 #@   ]
 #@   return "\n".join(lines)
 #@ end

--- a/tools/custom-organization-policy-library/build/custom-constraints/firewall/firewallRestrictPublicAccessRule.yaml
+++ b/tools/custom-organization-policy-library/build/custom-constraints/firewall/firewallRestrictPublicAccessRule.yaml
@@ -3,11 +3,30 @@
 
 #@ def condition():
 #@   lines = [
-#@     "(size(resource.allowed) > 0) &&",
 #@     "(",
-#@     "  resource.sourceRanges.exists(range, range == '0.0.0.0/0') ||",
-#@     "  resource.destinationRanges.exists(range, range == '0.0.0.0/0')",
+#@     "  resource.direction == 'INGRESS' &&",
+#@     "  resource.sourceRanges.exists(range, range == '0.0.0.0/0') &&",
+#@     "  !resource.allowed.all(rule,",
+#@     "    rule.IPProtocol == 'icmp' ||",
+#@     "    (rule.IPProtocol == 'tcp' && has(rule.ports) && rule.ports.all(p, p == '22' || p == '443' || p == '3389')) ||",
+#@     "    (rule.IPProtocol == 'udp' && has(rule.ports) && rule.ports.all(p, p == '3389')) ||",
+#@     "    (rule.IPProtocol == 'sctp' && has(rule.ports) && rule.ports.all(p, p == '22'))",
+#@     "  ) &&",
+#@     "  !resource.name.startsWith('gke-') &&",
+#@     "  !resource.name.startsWith('k8s-') &&",
+#@     "  !resource.name.endsWith('-hc') &&",
+#@     "  !resource.name.startsWith('k8s2-') &&",
+#@     "  !resource.name.startsWith('gkegw1-l7-') &&",
+#@     "  !resource.name.startsWith('gkemcg1-l7-')",
 #@     ")"
+#@   ]
+#@   return "\n".join(lines)
+#@ end
+
+#@ def description():
+#@   lines = [
+#@     "Prevent VPC firewall rules from 0.0.0.0/0 except for allowed protocols (ICMP,",
+#@     "TCP:22, TCP:443, TCP:3389, UDP:3389, SCTP:22). Excludes GKE-managed rules."
 #@   ]
 #@   return "\n".join(lines)
 #@ end
@@ -21,5 +40,5 @@ action_type: DENY
 method_types:
 - CREATE
 display_name: Restrict VPC Firewall rules allowing public Internet access
-description: Prevent the creation of VPC firewall rules with source or destination any IP address (0.0.0.0/0)
+description: #@ description()
 #@ end

--- a/tools/custom-organization-policy-library/samples/gcloud/constraints/firewall/firewallRestrictPublicAccessPolicyRule.yaml
+++ b/tools/custom-organization-policy-library/samples/gcloud/constraints/firewall/firewallRestrictPublicAccessPolicyRule.yaml
@@ -6,11 +6,11 @@ condition: |-
     rule.priority < 2147483644 &&
     rule.direction == 'INGRESS' &&
     rule.match.srcIpRanges.exists(range, range == '0.0.0.0/0') &&
-    !rule.match.layer4Configs.exists(l4,
+    !rule.match.layer4Configs.all(l4,
       l4.ipProtocol == 'icmp' ||
-      (l4.ipProtocol == 'tcp' && has(l4.ports) && '443' in l4.ports) ||
-      (l4.ipProtocol == 'udp' && has(l4.ports) && '3389' in l4.ports) ||
-      (l4.ipProtocol == 'sctp' && has(l4.ports) && '22' in l4.ports)
+      (l4.ipProtocol == 'tcp' && has(l4.ports) && l4.ports.all(p, p == '22' || p == '443' || p == '3389')) ||
+      (l4.ipProtocol == 'udp' && has(l4.ports) && l4.ports.all(p, p == '3389')) ||
+      (l4.ipProtocol == 'sctp' && has(l4.ports) && l4.ports.all(p, p == '22'))
     )
   )
 action_type: DENY
@@ -19,5 +19,5 @@ method_types:
 - UPDATE
 display_name: Restrict Firewall Policy rules allowing public Internet access
 description: |-
-  Prevent Firewall Policy rules from 0.0.0.0/0 except for allowed protocols (ICMP, TCP:443, UDP:3389,
-  SCTP:22). TCP:22 and TCP:3389 are handled by separate constraints.
+  Prevent Firewall Policy rules from 0.0.0.0/0 except for allowed protocols (ICMP,
+  TCP:22, TCP:443, TCP:3389, UDP:3389, SCTP:22).

--- a/tools/custom-organization-policy-library/samples/gcloud/constraints/firewall/firewallRestrictPublicAccessRule.yaml
+++ b/tools/custom-organization-policy-library/samples/gcloud/constraints/firewall/firewallRestrictPublicAccessRule.yaml
@@ -2,13 +2,26 @@ name: organizations/11111111/customConstraints/custom.firewallRestrictPublicAcce
 resource_types:
 - compute.googleapis.com/Firewall
 condition: |-
-  (size(resource.allowed) > 0) &&
   (
-    resource.sourceRanges.exists(range, range == '0.0.0.0/0') ||
-    resource.destinationRanges.exists(range, range == '0.0.0.0/0')
+    resource.direction == 'INGRESS' &&
+    resource.sourceRanges.exists(range, range == '0.0.0.0/0') &&
+    !resource.allowed.all(rule,
+      rule.IPProtocol == 'icmp' ||
+      (rule.IPProtocol == 'tcp' && has(rule.ports) && rule.ports.all(p, p == '22' || p == '443' || p == '3389')) ||
+      (rule.IPProtocol == 'udp' && has(rule.ports) && rule.ports.all(p, p == '3389')) ||
+      (rule.IPProtocol == 'sctp' && has(rule.ports) && rule.ports.all(p, p == '22'))
+    ) &&
+    !resource.name.startsWith('gke-') &&
+    !resource.name.startsWith('k8s-') &&
+    !resource.name.endsWith('-hc') &&
+    !resource.name.startsWith('k8s2-') &&
+    !resource.name.startsWith('gkegw1-l7-') &&
+    !resource.name.startsWith('gkemcg1-l7-')
   )
 action_type: DENY
 method_types:
 - CREATE
 display_name: Restrict VPC Firewall rules allowing public Internet access
-description: Prevent the creation of VPC firewall rules with source or destination any IP address (0.0.0.0/0)
+description: |-
+  Prevent VPC firewall rules from 0.0.0.0/0 except for allowed protocols (ICMP,
+  TCP:22, TCP:443, TCP:3389, UDP:3389, SCTP:22). Excludes GKE-managed rules.

--- a/tools/custom-organization-policy-library/samples/tf/custom-constraints/custom.firewallRestrictPublicAccessPolicyRule.yaml
+++ b/tools/custom-organization-policy-library/samples/tf/custom-constraints/custom.firewallRestrictPublicAccessPolicyRule.yaml
@@ -5,16 +5,15 @@ custom.firewallRestrictPublicAccessPolicyRule:
       rule.priority < 2147483644 &&
       rule.direction == 'INGRESS' &&
       rule.match.srcIpRanges.exists(range, range == '0.0.0.0/0') &&
-      !rule.match.layer4Configs.exists(l4,
+      !rule.match.layer4Configs.all(l4,
         l4.ipProtocol == 'icmp' ||
-        (l4.ipProtocol == 'tcp' && has(l4.ports) && '443' in l4.ports) ||
-        (l4.ipProtocol == 'udp' && has(l4.ports) && '3389' in l4.ports) ||
-        (l4.ipProtocol == 'sctp' && has(l4.ports) && '22' in l4.ports)
+        (l4.ipProtocol == 'tcp' && has(l4.ports) && l4.ports.all(p, p == '22' || p == '443' || p == '3389')) ||
+        (l4.ipProtocol == 'udp' && has(l4.ports) && l4.ports.all(p, p == '3389')) ||
+        (l4.ipProtocol == 'sctp' && has(l4.ports) && l4.ports.all(p, p == '22'))
       )
     )
   description: Prevent Firewall Policy rules from 0.0.0.0/0 except for allowed protocols
-    (ICMP, TCP:443, UDP:3389, SCTP:22). TCP:22 and TCP:3389 are handled by separate
-    constraints.
+    (ICMP, TCP:22, TCP:443, TCP:3389, UDP:3389, SCTP:22).
   display_name: Restrict Firewall Policy rules allowing public Internet access
   method_types:
   - CREATE

--- a/tools/custom-organization-policy-library/samples/tf/custom-constraints/custom.firewallRestrictPublicAccessRule.yaml
+++ b/tools/custom-organization-policy-library/samples/tf/custom-constraints/custom.firewallRestrictPublicAccessRule.yaml
@@ -1,13 +1,24 @@
 custom.firewallRestrictPublicAccessRule:
   action_type: DENY
   condition: |-
-    (size(resource.allowed) > 0) &&
     (
-      resource.sourceRanges.exists(range, range == '0.0.0.0/0') ||
-      resource.destinationRanges.exists(range, range == '0.0.0.0/0')
+      resource.direction == 'INGRESS' &&
+      resource.sourceRanges.exists(range, range == '0.0.0.0/0') &&
+      !resource.allowed.all(rule,
+        rule.IPProtocol == 'icmp' ||
+        (rule.IPProtocol == 'tcp' && has(rule.ports) && rule.ports.all(p, p == '22' || p == '443' || p == '3389')) ||
+        (rule.IPProtocol == 'udp' && has(rule.ports) && rule.ports.all(p, p == '3389')) ||
+        (rule.IPProtocol == 'sctp' && has(rule.ports) && rule.ports.all(p, p == '22'))
+      ) &&
+      !resource.name.startsWith('gke-') &&
+      !resource.name.startsWith('k8s-') &&
+      !resource.name.endsWith('-hc') &&
+      !resource.name.startsWith('k8s2-') &&
+      !resource.name.startsWith('gkegw1-l7-') &&
+      !resource.name.startsWith('gkemcg1-l7-')
     )
-  description: Prevent the creation of VPC firewall rules with source or destination
-    any IP address (0.0.0.0/0)
+  description: Prevent VPC firewall rules from 0.0.0.0/0 except for allowed protocols
+    (ICMP, TCP:22, TCP:443, TCP:3389, UDP:3389, SCTP:22). Excludes GKE-managed rules.
   display_name: Restrict VPC Firewall rules allowing public Internet access
   method_types:
   - CREATE

--- a/tools/custom-organization-policy-library/tests/test_cases/firewall/policy_rule_open_firewall.yaml
+++ b/tools/custom-organization-policy-library/tests/test_cases/firewall/policy_rule_open_firewall.yaml
@@ -19,6 +19,7 @@ firewall_policy_allowed_icmp_world:
     expected_result:
       return_code: 0
 
+# TCP:22 is allowed as an exception in PublicAccessPolicyRule but blocked by SshPolicyRule
 firewall_policy_allowed_ssh_world:
   steps:
   - command_flags:
@@ -26,7 +27,7 @@ firewall_policy_allowed_ssh_world:
       src-ip-ranges: 0.0.0.0/0
     expected_result:
       return_code: 1
-      stderr: 'customConstraints/custom\.firewallRestrict(PublicAccess|Ssh)PolicyRule'
+      stderr: 'customConstraints/custom\.firewallRestrictSshPolicyRule'
 
 firewall_policy_allowed_https_world:
   steps:
@@ -36,6 +37,7 @@ firewall_policy_allowed_https_world:
     expected_result:
       return_code: 0
 
+# TCP:3389 is allowed as an exception in PublicAccessPolicyRule but blocked by RdpPolicyRule
 firewall_policy_allowed_rdp_tcp_world:
   steps:
   - command_flags:
@@ -43,7 +45,7 @@ firewall_policy_allowed_rdp_tcp_world:
       src-ip-ranges: 0.0.0.0/0
     expected_result:
       return_code: 1
-      stderr: 'customConstraints/custom\.firewallRestrict(PublicAccess|Rdp)PolicyRule'
+      stderr: 'customConstraints/custom\.firewallRestrictRdpPolicyRule'
 
 firewall_policy_allowed_rdp_udp_world:
   steps:

--- a/tools/custom-organization-policy-library/tests/test_cases/firewall/vpc_rule_open_firewall.yaml
+++ b/tools/custom-organization-policy-library/tests/test_cases/firewall/vpc_rule_open_firewall.yaml
@@ -14,15 +14,16 @@ shared_config:
     - open-firewall
 
 # Allowed: Safe protocols with 0.0.0.0/0
+# ICMP is allowed as an exception in PublicAccessRule
 firewall_vpc_allowed_icmp_world:
   steps:
   - command_flags:
       rules: icmp
       source-ranges: 0.0.0.0/0
     expected_result:
-      return_code: 1
-      stderr: 'customConstraints/custom\.firewallRestrictPublicAccessRule'
+      return_code: 0
 
+# TCP:22 is allowed as an exception in PublicAccessRule but blocked by SshRule
 firewall_vpc_allowed_ssh_world:
   steps:
   - command_flags:
@@ -30,17 +31,18 @@ firewall_vpc_allowed_ssh_world:
       source-ranges: 0.0.0.0/0
     expected_result:
       return_code: 1
-      stderr: 'customConstraints/custom\.firewallRestrict(PublicAccess|Ssh)Rule'
+      stderr: 'customConstraints/custom\.firewallRestrictSshRule'
 
+# TCP:443 is allowed as an exception in PublicAccessRule
 firewall_vpc_allowed_https_world:
   steps:
   - command_flags:
       rules: tcp:443
       source-ranges: 0.0.0.0/0
     expected_result:
-      return_code: 1
-      stderr: 'customConstraints/custom\.firewallRestrictPublicAccessRule'
+      return_code: 0
 
+# TCP:3389 is allowed as an exception in PublicAccessRule but blocked by RdpRule
 firewall_vpc_allowed_rdp_tcp_world:
   steps:
   - command_flags:
@@ -48,16 +50,16 @@ firewall_vpc_allowed_rdp_tcp_world:
       source-ranges: 0.0.0.0/0
     expected_result:
       return_code: 1
-      stderr: 'customConstraints/custom\.firewallRestrict(PublicAccess|Rdp)Rule'
+      stderr: 'customConstraints/custom\.firewallRestrictRdpRule'
 
+# UDP:3389 is allowed as an exception in PublicAccessRule
 firewall_vpc_allowed_rdp_udp_world:
   steps:
   - command_flags:
       rules: udp:3389
       source-ranges: 0.0.0.0/0
     expected_result:
-      return_code: 1
-      stderr: 'customConstraints/custom\.firewallRestrictPublicAccessRule'
+      return_code: 0
 
 # Denied: Unsafe protocols with 0.0.0.0/0
 firewall_vpc_denied_http_world:


### PR DESCRIPTION
## Summary

- Updates `firewallRestrictPublicAccessRule` (VPC) and `firewallRestrictPublicAccessPolicyRule` (Firewall Policy) constraints to improve detection of overly permissive rules
- Adds protocol exceptions for safe traffic patterns aligned with SCC's OPEN_FIREWALL finding logic
- Adds GKE-managed rule exclusions to prevent false positives on auto-generated firewall rules

## Changes

### VPC Constraint (`firewallRestrictPublicAccessRule`)
- Added `INGRESS` direction check (was missing)
- Removed `destinationRanges` check (not relevant for OPEN_FIREWALL finding)
- Added protocol exceptions using `!resource.allowed.all(rule, safe_condition)`:
  - ICMP (any ports)
  - TCP: 22, 443, 3389
  - UDP: 3389
  - SCTP: 22
- Added GKE exclusion patterns: `gke-*`, `k8s-*`, `k8s2-*`, `*-hc`, `gkegw1-l7-*`, `gkemcg1-l7-*`

### Policy Constraint (`firewallRestrictPublicAccessPolicyRule`)
- Changed `!exists(safe)` to `!all(safe)` - ensures ALL l4Configs are safe protocols
- Changed `'port' in l4.ports` to `l4.ports.all(p, ...)` - ensures ALL ports are safe
- Added TCP:22 and TCP:3389 to exceptions (previously handled by separate constraints)

### Test Updates
- Updated VPC and Policy test expectations to reflect new behavior
- ICMP, TCP:443, UDP:3389 from 0.0.0.0/0 now pass (allowed exceptions)
- TCP:22 and TCP:3389 from 0.0.0.0/0 now blocked only by dedicated SSH/RDP constraints

## Test plan

- [x] Constraints build successfully with `make build` and `make build-tf`
- [x] CEL expressions are within limits (~500-600 chars, 4 levels recursion)
- [x] Test YAML files parse correctly
- [ ] Deploy constraints to test environment with `make deploy-constraints`
- [ ] Run integration tests with `pytest main.py -m firewall`